### PR TITLE
delete duplicate deleteSavedPosters function

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -201,17 +201,5 @@ function deleteSavedPoster() {
       savedPosters.splice(i, 1);
     }
   }
-  showSavedPosters()
-}
-
-savedPostersGrid.addEventListener('dblclick', deleteSavedPoster);
-
-function deleteSavedPoster() {
-  var id = Number(event.target.id)
-   for(i = 0; i < savedPosters.length; i++) {
-    if (savedPosters[i].id === id) {
-      savedPosters.splice(i, 1);
-    }
-  }
   showSavedPosters();
 }


### PR DESCRIPTION
I deleted lines 197 - 208. They contained a duplicate function. 
I tested the webpage after the deletion to make sure everything was still functioning properly.
Feel free to reach out on Slack if there are any questions. 
